### PR TITLE
Random Route

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -5,7 +5,7 @@ declared-services:
     plan: Shared
 applications:
 - name: fieldwork
-  host: fieldwork
+  random-route: true
   memory: 128M
   disk_quota: 512M
   path: .


### PR DESCRIPTION
Uses a random route rather than specifying the host. If you specify the host, then everyone who goes to deploy this sample app (other than the original creator) will get the following error message:

```
Creating route fieldwork.mybluemix.net...
FAILED
Server error, status code: 400, error code: 210003, message: The host is taken: fieldwork
```

The annoying thing about random routes, though, is that Bluemix will create a new random route on each deployment (rather than just on the initial deployment). You may want to include a note about this in the README.