### PR TITLE
Update Version of Deployment Tracker Client

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/ibm-cds-labs/fieldwork",
   "dependencies": {
     "body-parser": "^1.11.0",
-    "cf-deployment-tracker-client": "^0.0.7",
+    "cf-deployment-tracker-client": "^0.x",
     "cloudant": "^1.0.0-beta3",
     "commander": "^2.6.0",
     "cookie-parser": "^1.3.4",


### PR DESCRIPTION
A new version of the Deployment Tracker client is now available. This new version, `0.1.1`, adds the ability to track bound services and runtime. This pull request updates the version string for `cf-deployment-tracker-client` to `^0.x`. The Deployment Tracker client uses semantic versioning (even in pre-1.0 releases). Rather than simply upgrading to `0.1.1`, this pull request allows for automatic updates when new minor and patch versions are made available. While a caret version range such as `^0.1.1` would be preferable, caret version ranges only allow for patch and minor updates ​for versions `1.0.0` and above.